### PR TITLE
Use Windows specific environment calls for better Windows compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "subprojects/dxil-spirv"]
 	path = subprojects/dxil-spirv
-	url = https://github.com/HansKristian-Work/dxil-spirv
+	url = https://github.com/Juice-Labs/dxil-spirv.git
 [submodule "subprojects/Vulkan-Headers"]
 	path = subprojects/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers

--- a/include/private/vkd3d_platform.h
+++ b/include/private/vkd3d_platform.h
@@ -37,6 +37,8 @@ int vkd3d_dlclose(vkd3d_module_t handle);
 
 const char *vkd3d_dlerror(void);
 
+bool vkd3d_get_env_var(const char* name, char value[VKD3D_PATH_MAX]);
+
 bool vkd3d_get_program_name(char program_name[VKD3D_PATH_MAX]);
 
 #endif

--- a/libs/vkd3d-common/debug.c
+++ b/libs/vkd3d-common/debug.c
@@ -20,6 +20,8 @@
 #include "vkd3d_debug.h"
 #include "vkd3d_threads.h"
 
+#include "vkd3d_platform.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
@@ -58,13 +60,13 @@ static FILE *vkd3d_log_file;
 
 static void vkd3d_dbg_init_once(void)
 {
-    const char *vkd3d_debug;
+    char vkd3d_debug[VKD3D_PATH_MAX];
     unsigned int channel, i;
 
     for (channel = 0; channel < VKD3D_DBG_CHANNEL_COUNT; channel++)
     {
-        if (!(vkd3d_debug = getenv(env_for_channel[channel])))
-            vkd3d_debug = "";
+        if (!vkd3d_get_env_var(env_for_channel[channel], vkd3d_debug))
+            strncpy(vkd3d_debug, "", VKD3D_PATH_MAX);
 
         for (i = 1; i < ARRAY_SIZE(debug_level_names); ++i)
             if (!strcmp(debug_level_names[i], vkd3d_debug))
@@ -75,7 +77,7 @@ static void vkd3d_dbg_init_once(void)
             vkd3d_dbg_level[channel] = VKD3D_DBG_LEVEL_FIXME;
     }
 
-    if ((vkd3d_debug = getenv("VKD3D_LOG_FILE")))
+    if (vkd3d_get_env_var("VKD3D_LOG_FILE", vkd3d_debug))
     {
         vkd3d_log_file = fopen(vkd3d_debug, "w");
         if (!vkd3d_log_file)
@@ -281,11 +283,13 @@ const char *debugstr_w(const WCHAR *wstr)
 
 unsigned int vkd3d_env_var_as_uint(const char *name, unsigned int default_value)
 {
-    const char *value = getenv(name);
+    char value[VKD3D_PATH_MAX] = {};
+
+    vkd3d_get_env_var(name, value);
     unsigned long r;
     char *end_ptr;
 
-    if (value)
+    if (strlen(value) > 0)
     {
         errno = 0;
         r = strtoul(value, &end_ptr, 0);

--- a/libs/vkd3d-common/profiling.c
+++ b/libs/vkd3d-common/profiling.c
@@ -21,6 +21,7 @@
 #define VKD3D_DBG_CHANNEL VKD3D_DBG_CHANNEL_API
 
 #include "vkd3d_profiling.h"
+#include "vkd3d_platform.h"
 #include "vkd3d_threads.h"
 #include "vkd3d_debug.h"
 #include <stdlib.h>
@@ -124,8 +125,9 @@ static void vkd3d_init_profiling_path(const char *path)
 
 static void vkd3d_init_profiling_once(void)
 {
-    const char *path = getenv("VKD3D_PROFILE_PATH");
-    if (path)
+    char path[VKD3D_PATH_MAX];
+    vkd3d_get_env_var("VKD3D_PROFILE_PATH", path);
+    if (strlen(path) > 0)
         vkd3d_init_profiling_path(path);
 }
 

--- a/libs/vkd3d-shader/vkd3d_shader_main.c
+++ b/libs/vkd3d-shader/vkd3d_shader_main.c
@@ -20,6 +20,8 @@
 
 #include "vkd3d_shader_private.h"
 
+#include "vkd3d_platform.h"
+
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -82,12 +84,12 @@ bool vkd3d_shader_replace(vkd3d_shader_hash_t hash, const void **data, size_t *s
 {
     static bool enabled = true;
     char filename[1024];
-    const char *path;
+    char path[VKD3D_PATH_MAX];
 
     if (!enabled)
         return false;
 
-    if (!(path = getenv("VKD3D_SHADER_OVERRIDE")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_OVERRIDE", path))
     {
         enabled = false;
         return false;
@@ -101,12 +103,12 @@ bool vkd3d_shader_replace_export(vkd3d_shader_hash_t hash, const void **data, si
 {
     static bool enabled = true;
     char filename[1024];
-    const char *path;
+    char path[VKD3D_PATH_MAX];
 
     if (!enabled)
         return false;
 
-    if (!(path = getenv("VKD3D_SHADER_OVERRIDE")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_OVERRIDE", path))
     {
         enabled = false;
         return false;
@@ -119,12 +121,12 @@ bool vkd3d_shader_replace_export(vkd3d_shader_hash_t hash, const void **data, si
 void vkd3d_shader_dump_shader(vkd3d_shader_hash_t hash, const struct vkd3d_shader_code *shader, const char *ext)
 {
     static bool enabled = true;
-    const char *path;
+    char path[VKD3D_PATH_MAX];
 
     if (!enabled)
         return;
 
-    if (!(path = getenv("VKD3D_SHADER_DUMP_PATH")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DUMP_PATH", path))
     {
         enabled = false;
         return;
@@ -136,12 +138,12 @@ void vkd3d_shader_dump_shader(vkd3d_shader_hash_t hash, const struct vkd3d_shade
 void vkd3d_shader_dump_spirv_shader(vkd3d_shader_hash_t hash, const struct vkd3d_shader_code *shader)
 {
     static bool enabled = true;
-    const char *path;
+    char path[VKD3D_PATH_MAX];
 
     if (!enabled)
         return;
 
-    if (!(path = getenv("VKD3D_SHADER_DUMP_PATH")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DUMP_PATH", path))
     {
         enabled = false;
         return;
@@ -154,13 +156,13 @@ void vkd3d_shader_dump_spirv_shader_export(vkd3d_shader_hash_t hash, const struc
         const char *export)
 {
     static bool enabled = true;
-    const char *path;
+    char path[VKD3D_PATH_MAX];
     char tag[1024];
 
     if (!enabled)
         return;
 
-    if (!(path = getenv("VKD3D_SHADER_DUMP_PATH")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DUMP_PATH", path))
     {
         enabled = false;
         return;

--- a/libs/vkd3d/debug_ring.c
+++ b/libs/vkd3d/debug_ring.c
@@ -21,6 +21,7 @@
 #include "vkd3d_private.h"
 #include "vkd3d_debug.h"
 #include "vkd3d_common.h"
+#include "vkd3d_platform.h"
 #include <stdio.h>
 
 void vkd3d_shader_debug_ring_init_spec_constant(struct d3d12_device *device,
@@ -175,10 +176,10 @@ HRESULT vkd3d_shader_debug_ring_init(struct vkd3d_shader_debug_ring *ring,
     const struct vkd3d_vk_device_procs *vk_procs = &device->vk_procs;
     D3D12_HEAP_PROPERTIES heap_properties;
     D3D12_RESOURCE_DESC resource_desc;
-    const char *env;
+    char env[VKD3D_PATH_MAX];
 
     memset(ring, 0, sizeof(*ring));
-    if (!(env = getenv("VKD3D_SHADER_DEBUG_RING_SIZE_LOG2")))
+    if (!vkd3d_get_env_var("VKD3D_SHADER_DEBUG_RING_SIZE_LOG2", env))
         return S_OK;
 
     ring->active = true;

--- a/libs/vkd3d/device.c
+++ b/libs/vkd3d/device.c
@@ -21,6 +21,7 @@
 #include "vkd3d_private.h"
 #include "vkd3d_sonames.h"
 #include "vkd3d_descriptor_debug.h"
+#include "vkd3d_platform.h"
 
 #ifdef VKD3D_ENABLE_RENDERDOC
 #include "vkd3d_renderdoc.h"
@@ -124,9 +125,9 @@ static unsigned int get_spec_version(const VkExtensionProperties *extensions,
 
 static bool is_extension_disabled(const char *extension_name)
 {
-    const char *disabled_extensions;
+    char disabled_extensions[VKD3D_PATH_MAX];
 
-    if (!(disabled_extensions = getenv("VKD3D_DISABLE_EXTENSIONS")))
+    if (!vkd3d_get_env_var("VKD3D_DISABLE_EXTENSIONS", disabled_extensions))
         return false;
 
     return vkd3d_debug_list_has_member(disabled_extensions, extension_name);
@@ -507,9 +508,9 @@ static const struct vkd3d_debug_option vkd3d_config_options[] =
 
 static void vkd3d_config_flags_init_once(void)
 {
-    const char *config;
+    char config[VKD3D_PATH_MAX] = {};
 
-    config = getenv("VKD3D_CONFIG");
+    vkd3d_get_env_var("VKD3D_CONFIG", config);
     vkd3d_config_flags = vkd3d_parse_debug_options(config, vkd3d_config_options, ARRAY_SIZE(vkd3d_config_options));
 
     if (!(vkd3d_config_flags & VKD3D_CONFIG_FLAG_SKIP_APPLICATION_WORKAROUNDS))
@@ -1808,12 +1809,12 @@ static HRESULT vkd3d_select_physical_device(struct vkd3d_instance *instance,
     VkPhysicalDeviceProperties device_properties;
     VkPhysicalDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice *physical_devices;
-    const char *filter;
+    char filter[VKD3D_PATH_MAX] = {};
     uint32_t count;
     unsigned int i;
     VkResult vr;
 
-    filter = getenv("VKD3D_FILTER_DEVICE_NAME");
+    vkd3d_get_env_var("VKD3D_FILTER_DEVICE_NAME", filter);
 
     count = 0;
     if ((vr = VK_CALL(vkEnumeratePhysicalDevices(vk_instance, &count, NULL))) < 0)
@@ -5151,7 +5152,7 @@ static void d3d12_device_caps_override(struct d3d12_device *device)
 {
     D3D_FEATURE_LEVEL fl_override = (D3D_FEATURE_LEVEL)0;
     struct d3d12_caps *caps = &device->d3d12_caps;
-    const char* fl_string;
+    char fl_string[VKD3D_PATH_MAX];
     unsigned int i;
 
     static const struct
@@ -5168,7 +5169,7 @@ static void d3d12_device_caps_override(struct d3d12_device *device)
         { "12_2", D3D_FEATURE_LEVEL_12_2 },
     };
 
-    if (!(fl_string = getenv("VKD3D_FEATURE_LEVEL")))
+    if (!vkd3d_get_env_var("VKD3D_FEATURE_LEVEL", fl_string))
         return;
 
     for (i = 0; i < ARRAY_SIZE(feature_levels); i++)

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -24,30 +24,41 @@
 static void vkd3d_memory_allocator_wait_allocation(struct vkd3d_memory_allocator *allocator,
         struct d3d12_device *device, const struct vkd3d_memory_allocation *allocation);
 
-static uint32_t vkd3d_select_memory_types(struct d3d12_device *device, const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags)
+static HRESULT vkd3d_select_memory_types(struct d3d12_device *device,
+        const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags, uint32_t *type_mask)
 {
     const VkPhysicalDeviceMemoryProperties *memory_info = &device->memory_properties;
-    uint32_t type_mask = (1 << memory_info->memoryTypeCount) - 1;
     const struct vkd3d_memory_info_domain *domain_info;
 
     domain_info = d3d12_device_get_memory_info_domain(device, heap_properties);
 
-    if (!(heap_flags & D3D12_HEAP_FLAG_DENY_BUFFERS))
-        type_mask &= domain_info->buffer_type_mask;
-
-    if (!(heap_flags & D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES))
-        type_mask &= domain_info->sampled_type_mask;
+    *type_mask = 0;
 
     /* Render targets are not allowed on UPLOAD and READBACK heaps */
     if (!(heap_flags & D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES) &&
-            heap_properties->Type != D3D12_HEAP_TYPE_UPLOAD &&
-            heap_properties->Type != D3D12_HEAP_TYPE_READBACK)
-        type_mask &= domain_info->rt_ds_type_mask;
+            (heap_properties->Type == D3D12_HEAP_TYPE_UPLOAD ||
+            heap_properties->Type == D3D12_HEAP_TYPE_READBACK))
+    {
+        ERR("Render targets are not allowed on UPLOAD and READBACK heaps.\n");
+        return E_INVALIDARG;
+    }
 
-    if (!type_mask)
+    if (!(heap_flags & D3D12_HEAP_FLAG_DENY_BUFFERS))
+        *type_mask |= domain_info->buffer_type_mask;
+
+    if (!(heap_flags & D3D12_HEAP_FLAG_DENY_NON_RT_DS_TEXTURES))
+        *type_mask |= domain_info->sampled_type_mask;
+
+    if (!(heap_flags & D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES))
+        *type_mask |= domain_info->rt_ds_type_mask;
+
+    if (!(*type_mask))
+    {
         ERR("No memory type found for heap flags %#x.\n", heap_flags);
+        return E_FAIL;
+    }
 
-    return type_mask;
+    return S_OK;
 }
 
 static uint32_t vkd3d_find_memory_types_with_flags(struct d3d12_device *device, VkMemoryPropertyFlags type_flags)
@@ -502,11 +513,11 @@ static HRESULT vkd3d_memory_allocation_init(struct vkd3d_memory_allocation *allo
     /* If an allocation is a dedicated fallback allocation,
      * we must not look at heap_flags, since we might end up noping out
      * the memory types we want to allocate with. */
-    type_mask = memory_requirements.memoryTypeBits;
     if (info->flags & VKD3D_ALLOCATION_FLAG_DEDICATED)
-        type_mask &= device->memory_info.global_mask;
-    else
-        type_mask &= vkd3d_select_memory_types(device, &info->heap_properties, info->heap_flags);
+        type_mask = device->memory_info.global_mask;
+    else if (FAILED(hr = vkd3d_select_memory_types(device, &info->heap_properties, info->heap_flags, &type_mask)))
+        return hr;
+    type_mask &= memory_requirements.memoryTypeBits;
 
     /* Allocate actual backing storage */
     flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
@@ -1384,6 +1395,7 @@ HRESULT vkd3d_allocate_memory(struct d3d12_device *device, struct vkd3d_memory_a
 static bool vkd3d_heap_allocation_accept_deferred_resource_placements(struct d3d12_device *device,
         const D3D12_HEAP_PROPERTIES *heap_properties, D3D12_HEAP_FLAGS heap_flags)
 {
+    HRESULT hr;
     uint32_t type_mask;
 
     /* Normally, if a memory allocation fails, we consider it an error, but there are some exceptions
@@ -1396,7 +1408,9 @@ static bool vkd3d_heap_allocation_accept_deferred_resource_placements(struct d3d
     if (is_cpu_accessible_heap(heap_properties))
         return false;
 
-    type_mask = vkd3d_select_memory_types(device, heap_properties, heap_flags);
+    if (FAILED(hr = vkd3d_select_memory_types(device, heap_properties, heap_flags, &type_mask)))
+        return false;
+
     return device->memory_properties.memoryHeapCount > 1 &&
             !vkd3d_memory_info_type_mask_covers_multiple_memory_heaps(&device->memory_properties, type_mask);
 }

--- a/libs/vkd3d/memory.c
+++ b/libs/vkd3d/memory.c
@@ -292,25 +292,9 @@ HRESULT vkd3d_allocate_device_memory(struct d3d12_device *device,
 
     if (FAILED(hr) && (type_flags & optional_flags))
     {
-        if (vkd3d_memory_info_type_mask_covers_multiple_memory_heaps(&device->memory_properties, type_mask))
-        {
-            WARN("Memory allocation failed, falling back to system memory.\n");
-            hr = vkd3d_try_allocate_device_memory(device, size,
-                    type_flags & ~optional_flags, type_mask, pNext, allocation);
-        }
-        else if (device->memory_properties.memoryHeapCount > 1)
-        {
-            /* It might be the case (NV with RT/DS heap) that we just cannot fall back in any meaningful way.
-             * E.g. there exists no memory type that is not DEVICE_LOCAL and covers both RT and DS.
-             * For this case, we have no choice but to not allocate,
-             * and defer actual memory allocation to CreatePlacedResource() time.
-			 * NVIDIA bug reference for fixing this case: 2175829. */
-            WARN("Memory allocation failed, but it is not possible to fallback to system memory here. Deferring allocation.\n");
-            return hr;
-        }
-
-        /* If we fail to allocate, and only have one heap to work with (iGPU),
-         * falling back is meaningless, just fail. */
+        WARN("Memory allocation failed, falling back to system memory.\n");
+        hr = vkd3d_try_allocate_device_memory(device, size,
+                type_flags & ~optional_flags, type_mask, pNext, allocation);
     }
 
     if (FAILED(hr))

--- a/libs/vkd3d/platform.c
+++ b/libs/vkd3d/platform.c
@@ -43,6 +43,18 @@ const char *vkd3d_dlerror(void)
     return dlerror();
 }
 
+bool vkd3d_get_env_var(const char* name, char value[VKD3D_PATH_MAX])
+{
+    const char* envValue = getenv(name);
+    if (envValue)
+    {
+        strncpy(value, envValue, VKD3D_PATH_MAX);
+        return true;
+    }
+
+    return false;
+}
+
 bool vkd3d_get_program_name(char program_name[VKD3D_PATH_MAX])
 {
     char *name, *p, *real_path = NULL;
@@ -98,6 +110,12 @@ int vkd3d_dlclose(vkd3d_module_t handle)
 const char *vkd3d_dlerror(void)
 {
     return "Not implemented for this platform.";
+}
+
+bool vkd3d_get_env_var(const char* name, char value[VKD3D_PATH_MAX])
+{
+    DWORD len = GetEnvironmentVariableA(name, value, VKD3D_PATH_MAX);
+    return len > 0;
 }
 
 bool vkd3d_get_program_name(char program_name[VKD3D_PATH_MAX])

--- a/libs/vkd3d/resource.c
+++ b/libs/vkd3d/resource.c
@@ -5946,7 +5946,7 @@ static uint32_t vkd3d_memory_info_find_global_mask(const struct vkd3d_memory_top
         }
     }
 
-    return ~mask;
+    return (~mask) & ((1 << device->memory_properties.memoryTypeCount) - 1);
 }
 
 static void vkd3d_memory_info_init_budgets(struct vkd3d_memory_info *info,

--- a/setup-ninja-clang-cl-debug.bat
+++ b/setup-ninja-clang-cl-debug.bat
@@ -1,0 +1,3 @@
+set CC=clang-cl
+set CXX=clang-cl
+meson setup --backend=ninja --buildtype=debug build\debug

--- a/setup-ninja-clang-cl-debugoptimized.bat
+++ b/setup-ninja-clang-cl-debugoptimized.bat
@@ -1,0 +1,3 @@
+set CC=clang-cl
+set CXX=clang-cl
+meson setup --backend=ninja --buildtype=debugoptimized build\debugoptimized

--- a/setup-ninja-clang-cl-release.bat
+++ b/setup-ninja-clang-cl-release.bat
@@ -1,0 +1,3 @@
+set CC=clang-cl
+set CXX=clang-cl
+meson setup --backend=ninja --buildtype=release build\release

--- a/setup-vs-clang-cl-debug.bat
+++ b/setup-vs-clang-cl-debug.bat
@@ -1,0 +1,3 @@
+set CC=clang-cl
+set CXX=clang-cl
+meson setup --backend=vs2019 --buildtype=debug build\debug_vs2019

--- a/setup-vs-clang-cl-debugoptimized.bat
+++ b/setup-vs-clang-cl-debugoptimized.bat
@@ -1,0 +1,3 @@
+set CC=clang-cl
+set CXX=clang-cl
+meson setup --backend=vs2019 --buildtype=debugoptimized build\debugoptimized_vs2019

--- a/setup-vs-clang-cl-release.bat
+++ b/setup-vs-clang-cl-release.bat
@@ -1,0 +1,3 @@
+set CC=clang-cl
+set CXX=clang-cl
+meson setup --backend=vs2019 --buildtype=release build\release_vs2019


### PR DESCRIPTION
getenv has odd, deprecated behavior on Windows and GetEnvironmentVariable* is the preferred call on Windows. For Juice this allows us to easily automate setting of targeted debug log output locations.